### PR TITLE
Fix quick transition calculation for skips > 4.

### DIFF
--- a/src/AABriv/AbstractArea.class.st
+++ b/src/AABriv/AbstractArea.class.st
@@ -14,6 +14,11 @@ Class {
 	#category : #'AABriv-model'
 }
 
+{ #category : #'instance creation' }
+AbstractArea class >> withId: anAreaID [
+	 ^self new areaId: anAreaID; yourself
+]
+
 { #category : #adding }
 AbstractArea >> addEnemy: anEnemy [
 	enemies add: anEnemy

--- a/src/AABriv/Adventure.class.st
+++ b/src/AABriv/Adventure.class.st
@@ -131,18 +131,12 @@ Adventure >> printOn: aStream [
 
 { #category : #enumerating }
 Adventure >> quickTransitionsFor: aNumberOfJumps [
-	| rp quickTransitions |
+	| rp transitions percentageQuick |
 	rp := RunPlanned planFor: self jumpingBy: aNumberOfJumps.
-	rp cacheAreasEncounteredTo: self areas size.
-	
-	quickTransitions := OrderedCollection new.
-	1 to: rp areas size - 1 do: [ :index |
-		| area1 area2 |
-		area1 := rp areas at: index.
-		area2 := rp areas at: index + 1.
-		(area1 value isQuickTransitionTo: area2 value) ifTrue: [ quickTransitions add: area1 ]].
-	^ quickTransitions 
-
+	transitions := rp transitionsWhere: [:area1 :area2 | 
+		area1 isQuickTransitionTo: area2 ].
+	percentageQuick := (transitions size / rp uniqueTransitions) asFloat.
+	^percentageQuick -> transitions
 ]
 
 { #category : #initialization }

--- a/src/AABriv/AdventureTest.class.st
+++ b/src/AABriv/AdventureTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #helpers }
 AdventureTest >> fillWithRandomAreas: anAdventure [
-	1 to: 50 do: [ :i | anAdventure areaAt: i put: AbstractArea new ]
+	1 to: 50 do: [ :i | anAdventure areaAt: i put: (AbstractArea withId: i) ]
 ]
 
 { #category : #running }
@@ -19,48 +19,10 @@ AdventureTest >> setUp [
 ]
 
 { #category : #test }
-AdventureTest >> testCollectAreasWithOneJumpShouldContainHalfOfTheAreas [
-	| run |
-	run := RunPlanned planFor: adventure jumpingBy: 1.
-	self assert: (run collectAreasTo: 100) size equals: 50.
-	
-	
-	
-]
-
-{ #category : #test }
-AdventureTest >> testCollectAreasWithTwoJumpShouldContainsAThirdOfTheAreas [
-	| run |
-	run := RunPlanned planFor: adventure jumpingBy: 2.
-	self assert: (run collectAreasTo: 100) size equals: 34.
-	
-	
-	
-]
-
-{ #category : #test }
-AdventureTest >> testCollectAreasWithTwoJumpShouldHaveAsLastArea99 [
-	| run |
-	run := RunPlanned planFor: adventure jumpingBy: 2.
-	run cacheAreasEncounteredTo: 100.
-	self assert: run lastAreaNumber equals: 99.
-]
-
-{ #category : #test }
-AdventureTest >> testCollectAreasWithZeroJumpShouldContainAllAreas [
-	| run |
-	run := RunPlanned planFor: adventure jumpingBy: 0.
-	self assert: (run collectAreasTo: 100) size equals: 100.
-	
-	
-	
-]
-
-{ #category : #test }
 AdventureTest >> testFourBrivJumpWalksAllLevels [
 	| run |
 	run := RunPlanned planFor: adventure jumpingBy: 4.
-	self assert: (run howManyAreasTo: 100) equals: 20.
+	self assert: (run howManyTransitionsToArea: 100) equals: 20.
 	
 ]
 
@@ -68,7 +30,7 @@ AdventureTest >> testFourBrivJumpWalksAllLevels [
 AdventureTest >> testOneBrivJumpWalksAllLevels [
 	| run |
 	run := RunPlanned planFor: adventure jumpingBy: 1.
-	self assert: (run howManyAreasTo: 50) equals: 25.
+	self assert: (run howManyTransitionsToArea: 50) equals: 25.
 	
 ]
 
@@ -76,14 +38,68 @@ AdventureTest >> testOneBrivJumpWalksAllLevels [
 AdventureTest >> testThreeBrivJumpWalksAllLevels [
 	| run |
 	run := RunPlanned planFor: adventure jumpingBy: 3.
-	self assert: (run howManyAreasTo: 100) equals: 25.
+	self assert: (run howManyTransitionsToArea: 100) equals: 25.
 ]
 
 { #category : #test }
 AdventureTest >> testTwoBrivJumpWalksAllLevels [
 	| run |
 	run := RunPlanned planFor: adventure jumpingBy: 2.
-	self assert: (run howManyAreasTo: 100) equals: 34.
+	self assert: (run howManyTransitionsToArea: 100) equals: 34.
+	
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions1Jump [
+	self testUniqueTransitionsWhenJumping: 1
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions2Jump [
+	self testUniqueTransitionsWhenJumping: 2
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions3Jump [
+	self testUniqueTransitionsWhenJumping: 3
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions4Jump [
+	self testUniqueTransitionsWhenJumping: 4
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions5Jump [
+	self testUniqueTransitionsWhenJumping: 5
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions6Jump [
+	self testUniqueTransitionsWhenJumping: 6
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions7Jump [
+	self testUniqueTransitionsWhenJumping: 7
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions8Jump [
+	self testUniqueTransitionsWhenJumping: 8
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitions9Jump [
+	self testUniqueTransitionsWhenJumping: 9
+]
+
+{ #category : #test }
+AdventureTest >> testUniqueTransitionsWhenJumping: jumps [
+	"The number of unique transitions for a jump value is defined by the gcd, check we pass through the correct amount "
+	| run |
+	run := RunPlanned planFor: adventure jumpingBy: jumps.
+	self assert: (run transitionsWhere: [ true ]) size equals: run uniqueTransitions.
 	
 ]
 
@@ -91,6 +107,6 @@ AdventureTest >> testTwoBrivJumpWalksAllLevels [
 AdventureTest >> testZeroBrivJumpWalksAllLevels [
 	| run |
 	run := RunPlanned planFor: adventure jumpingBy: 0.
-	self assert: (run howManyAreasTo: 100) equals: 100.
+	self assert: (run howManyTransitionsToArea: 100) equals: 100.
 	
 ]

--- a/src/AABriv/IdleChampionDataBase.class.st
+++ b/src/AABriv/IdleChampionDataBase.class.st
@@ -34,8 +34,8 @@ IdleChampionDataBase >> allAdventures [
 IdleChampionDataBase >> allQuickTransitionsAdventuresFor: aNumberOfBrivJump [
 	| quickTransitionsAdventures |
 	quickTransitionsAdventures := self allAdventures collect: [ :a| a -> (a quickTransitionsFor: aNumberOfBrivJump) ].
-	quickTransitionsAdventures := quickTransitionsAdventures reject: [ :a| a value isEmpty ].
-	^ quickTransitionsAdventures sort:[ :a1 :a2 | a1 value size > a2 value size ].
+	quickTransitionsAdventures := quickTransitionsAdventures reject: [ :a| a value key = 0 ].
+	^ quickTransitionsAdventures sort:[ :a1 :a2 | a1 value key > a2 value key ].
 ]
 
 { #category : #'accessing-id' }

--- a/src/AABriv/RunPlanned.class.st
+++ b/src/AABriv/RunPlanned.class.st
@@ -3,8 +3,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'adventure',
-		'jumps',
-		'areas'
+		'jumps'
 	],
 	#category : #'AABriv-model'
 }
@@ -30,29 +29,7 @@ RunPlanned >> adventure: anObject [
 ]
 
 { #category : #query }
-RunPlanned >> areas [
-	^ areas
-]
-
-{ #category : #query }
-RunPlanned >> cacheAreasEncounteredTo: anInteger [
-	areas := self collectAreasTo: anInteger.
-]
-
-{ #category : #query }
-RunPlanned >> collectAreasTo: aMaxArea [
-	^ ((0 to: aMaxArea - 1 by: jumps + 1) 
-		collect: [ :i | i + 1  -> (adventure areaAt: (i rem: 50) + 1) ])
-		asOrderedCollection
-]
-
-{ #category : #query }
-RunPlanned >> encountersAreaNumber: anIndex [
-	^ (areas at: anIndex ifAbsent:[ nil ]) isNotNil
-]
-
-{ #category : #query }
-RunPlanned >> howManyAreasTo: anInteger [ 
+RunPlanned >> howManyTransitionsToArea: anInteger [ 
 	^ (1 to: anInteger by: jumps + 1) size
 ]
 
@@ -68,7 +45,28 @@ RunPlanned >> jumps: anObject [
 	jumps := anObject
 ]
 
+{ #category : #query }
+RunPlanned >> transitionsWhere: aBlock [
+	| firstArea transitioningFrom transitioningTo transitions |
+	firstArea := adventure areas first.
+	transitioningFrom := firstArea.
+	transitions := OrderedCollection new.
+	[ | nextAreaID|
+		nextAreaID := ((transitioningFrom areaId + self jumps) \\ (adventure areas size)) + 1.
+		transitioningTo := adventure areas at: nextAreaID.
+		(aBlock cull: transitioningFrom cull: transitioningTo) 
+			ifTrue: [transitions add: (transitioningFrom -> transitioningTo)]. 	
+		transitioningTo = firstArea ] 
+		whileFalse: [ transitioningFrom := transitioningTo ].
+	 ^transitions
+]
+
 { #category : #accessing }
-RunPlanned >> lastAreaNumber [
-	^ areas last key
+RunPlanned >> uniqueTransitions [
+	^adventure areas size / (adventure areas size gcd: jumps+1)
+]
+
+{ #category : #query }
+RunPlanned >> visitedAreasWhere: aBlock [
+	^(self transitionsWhere: aBlock) select: #key
 ]


### PR DESCRIPTION
Hi, thanks for the interesting database!

I rewrote the code in the initial playground example a bit, so it more accurate ranks skip values > 4 - 
what we're really interested in, is the % of transitions that will be quick, and for that we need to iterate through all the unique transitions at a certain skip level. 

The transitionsWhere:/areasWhere: methods should also be flexible tools if you want to test different filtering, like disregarding transitions leading to areas with ranged monsters.

Cheers,
Henry